### PR TITLE
Thrift version update, tests pass

### DIFF
--- a/thrift_client.gemspec
+++ b/thrift_client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency("thrift", ["~> 0.10.0"])
+  s.add_dependency("thrift", ["~> 0.11.0"])
 
   s.add_development_dependency 'rack'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
I was able to successfully update the `thrift` dependency to version `0.11.0` with tests passing.